### PR TITLE
Add an insecure option for minio

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Set a target directory for deployment (with a leading slash).'
     required: false
     default: '/'
+  insecure:
+    description: 'Trust SSL certificates with minio --insecure option'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -29,6 +33,7 @@ runs:
     MINIO_ENDPOINT: ${{ inputs.endpoint }}
     MINIO_ACCESS_KEY: ${{ inputs.access_key }}
     MINIO_SECRET_KEY: ${{ inputs.secret_key }}
+    MINIO_INSECURE: ${{ inputs.insecure }}
   args:
     - ${{ inputs.source_dir }}
     - '${{ inputs.bucket }}${{ inputs.target_dir }}'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euxo pipefail
+
 mc alias set deploy $MINIO_ENDPOINT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 
 mc mirror --overwrite $1 "deploy/$2"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,9 @@ set -euxo pipefail
 
 mc alias set deploy $MINIO_ENDPOINT $MINIO_ACCESS_KEY $MINIO_SECRET_KEY
 
-mc mirror --overwrite $1 "deploy/$2"
+insecure_option=""
+if ["$MINIO_INSECURE" == "true"]; then
+  insecure_option="--insecure"
+fi
+
+mc mirror --overwrite $insecure_option $1 "deploy/$2"


### PR DESCRIPTION
Add the possibility to trust SSL certificates using the Minio `--insecure` option.

See https://docs.min.io/docs/minio-client-complete-guide.html